### PR TITLE
Cleanup include guard and add missing dependency to TF core

### DIFF
--- a/tensorflow_networking/gdr/BUILD
+++ b/tensorflow_networking/gdr/BUILD
@@ -39,6 +39,7 @@ cc_library(
     ],
     deps = [
         ":gdr_proto_cc",
+        "@org_tensorflow//tensorflow/core:core",
     ],
 )
 
@@ -48,6 +49,7 @@ cc_library(
     hdrs = ["gdr_worker.h"],
     deps = [
         ":gdr_memory_manager",
+        "@org_tensorflow//tensorflow/core:core",
         "@org_tensorflow//tensorflow/core/distributed_runtime:graph_mgr",
         "@org_tensorflow//tensorflow/core/distributed_runtime:recent_request_ids",
         "@org_tensorflow//tensorflow/core/distributed_runtime:rendezvous_mgr_interface",
@@ -67,6 +69,7 @@ cc_library(
     hdrs = ["gdr_rendezvous_mgr.h"],
     deps = [
         ":gdr_memory_manager",
+        "@org_tensorflow//tensorflow/core:core",
         "@org_tensorflow//tensorflow/core/distributed_runtime:base_rendezvous_mgr",
         "@org_tensorflow//tensorflow/core/distributed_runtime:request_id",
         "@org_tensorflow//tensorflow/core/distributed_runtime:tensor_coding",

--- a/tensorflow_networking/gdr/gdr_memory_manager.cc
+++ b/tensorflow_networking/gdr/gdr_memory_manager.cc
@@ -13,8 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifdef TENSORFLOW_USE_GDR
-
 #include "tensorflow_networking/gdr/gdr_memory_manager.h"
 
 #include <atomic>
@@ -27,7 +25,6 @@ limitations under the License.
 #include <rdma/rdma_cma.h>
 #include <rdma/rdma_verbs.h>
 
-#include "tensorflow_networking/gdr/gdr.pb.h"
 #include "tensorflow/core/common_runtime/device.h"
 #include "tensorflow/core/common_runtime/dma_helper.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_process_state.h"
@@ -37,6 +34,8 @@ limitations under the License.
 #include "tensorflow/core/platform/macros.h"
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/numa.h"
+
+#include "tensorflow_networking/gdr/gdr.pb.h"
 
 namespace tensorflow {
 
@@ -616,5 +615,3 @@ RemoteMemoryManager* CreateRemoteMemoryManager(const string& host,
 }
 
 }  // namespace tensorflow
-
-#endif  // TENSORFLOW_USE_GDR

--- a/tensorflow_networking/gdr/gdr_rendezvous_mgr.cc
+++ b/tensorflow_networking/gdr/gdr_rendezvous_mgr.cc
@@ -16,7 +16,6 @@ limitations under the License.
 #include "tensorflow_networking/gdr/gdr_rendezvous_mgr.h"
 
 #include "google/protobuf/any.pb.h"
-#include "tensorflow_networking/gdr/gdr_memory_manager.h"
 #include "tensorflow/core/common_runtime/device.h"
 #include "tensorflow/core/common_runtime/device_mgr.h"
 #include "tensorflow/core/common_runtime/process_util.h"

--- a/tensorflow_networking/gdr/gdr_rendezvous_mgr.h
+++ b/tensorflow_networking/gdr/gdr_rendezvous_mgr.h
@@ -16,10 +16,11 @@ limitations under the License.
 #ifndef TENSORFLOW_CONTRIB_GDR_GDR_RENDEZVOUS_MGR_H_
 #define TENSORFLOW_CONTRIB_GDR_GDR_RENDEZVOUS_MGR_H_
 
-#include "tensorflow_networking/gdr/gdr_memory_manager.h"
 #include "tensorflow/core/distributed_runtime/base_rendezvous_mgr.h"
 #include "tensorflow/core/distributed_runtime/worker_env.h"
 #include "tensorflow/core/platform/macros.h"
+
+#include "tensorflow_networking/gdr/gdr_memory_manager.h"
 
 namespace tensorflow {
 

--- a/tensorflow_networking/gdr/gdr_server_lib.cc
+++ b/tensorflow_networking/gdr/gdr_server_lib.cc
@@ -16,11 +16,9 @@ limitations under the License.
 #include "tensorflow_networking/gdr/gdr_server_lib.h"
 
 #include "grpc/support/alloc.h"
-#include "tensorflow_networking/gdr/gdr_memory_manager.h"
+
 #include "tensorflow_networking/gdr/gdr_rendezvous_mgr.h"
 #include "tensorflow_networking/gdr/gdr_worker.h"
-
-#include "grpc/support/alloc.h"
 
 namespace tensorflow {
 

--- a/tensorflow_networking/gdr/gdr_server_lib.h
+++ b/tensorflow_networking/gdr/gdr_server_lib.h
@@ -16,8 +16,9 @@ limitations under the License.
 #ifndef TENSORFLOW_CONTRIB_GDR_GDR_SERVER_LIB_H_
 #define TENSORFLOW_CONTRIB_GDR_GDR_SERVER_LIB_H_
 
-#include "tensorflow_networking/gdr/gdr_memory_manager.h"
 #include "tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h"
+
+#include "tensorflow_networking/gdr/gdr_memory_manager.h"
 
 namespace tensorflow {
 

--- a/tensorflow_networking/gdr/gdr_worker.h
+++ b/tensorflow_networking/gdr/gdr_worker.h
@@ -16,10 +16,10 @@ limitations under the License.
 #ifndef TENSORFLOW_CONTRIB_GDR_GDR_WORKER_H_
 #define TENSORFLOW_CONTRIB_GDR_GDR_WORKER_H_
 
-#include "tensorflow_networking/gdr/gdr_memory_manager.h"
-
 #include "tensorflow/core/distributed_runtime/recent_request_ids.h"
 #include "tensorflow/core/distributed_runtime/rpc/grpc_worker_service.h"
+
+#include "tensorflow_networking/gdr/gdr_memory_manager.h"
 
 namespace tensorflow {
 


### PR DESCRIPTION
To build GDR unconditionally in the new project, `TENSORFLOW_USE_GDR` macro is removed.

In `tensorflow/core/BUILD`:

```
Public targets:

":protos_all_cc" - exports all core TensorFlow protos
    ":protos_all_py" - py_proto_library version (Google-internal)
":lib" - exports the public non-test headers for:
    platform/: Platform-specific code and external dependencies
    lib/: Low-level libraries that are not TensorFlow-specific
":framework" - exports the public non-test headers for:
    util/: General low-level TensorFlow-specific libraries
    framework/: Support for adding new ops & kernels
    example/: Wrappers to simplify access to Example proto
":ops" - defines TensorFlow ops, but no implementations / kernels
    ops/: Standard ops
    user_ops/: User-supplied ops
    This aggregates a number of smaller op libraries (":*_op_lib")
":core_cpu" - exports the public non-test headers for:
    graph/: Support for graphs made up of ops
    common_runtime/: Common code for execution of graphs
    public/: Public APIs for running graphs
":core" - The code for ":core_cpu" plus a GPU runtime
":all_kernels" - The cpu-specific kernels, plus gpu kernels if built with Cuda
":tensorflow_opensource" - The complete open-source package, including ":all_kernels", ":core", and a Session implementation.
":tensorflow" - "tensorflow_opensource" plus some Google-internal libraries.
```

Since we need

* `common_runtime/`
* `common_runtime/gpu`
* `framework/`
* `lib/`
* `platform/`

we add a dependency to`tensorflow/core:core`.