### PR TITLE
Clang format

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,9 +11,9 @@ load("//tensorflow_networking:repo.bzl", "tensorflow_http_archive")
 
 tensorflow_http_archive(
     name = "org_tensorflow",
-    sha256 = "7b6393db1e7b41f324e6a04693a8fe8cb847eb1bbe0789bbd3f9e0c7789cb67c",
     git_commit = "f64f7f787d3596cb7c9228f131f06c159a0ec188",
     patch = "//third_party:tf-visibility.patch",
+    sha256 = "7b6393db1e7b41f324e6a04693a8fe8cb847eb1bbe0789bbd3f9e0c7789cb67c",
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -30,4 +30,7 @@ http_archive(
 
 load("@org_tensorflow//tensorflow:workspace.bzl", "tf_workspace")
 
-tf_workspace(path_prefix = "", tf_repo_name = "org_tensorflow")
+tf_workspace(
+    path_prefix = "",
+    tf_repo_name = "org_tensorflow",
+)

--- a/configure.py
+++ b/configure.py
@@ -93,7 +93,6 @@ def symlink_force(target, link_name):
       raise e
 
 
-
 def write_to_bazelrc(line):
   with open(_TF_BAZELRC, 'a') as f:
     f.write(line + '\n')
@@ -272,7 +271,6 @@ def set_action_env_var(environ_cp,
   environ_cp[var_name] = str(var)
 
 
-
 def get_from_env_or_user_or_default(environ_cp, var_name, ask_for_var,
                                     var_default):
   """Get var_name either from env, or user or default.
@@ -296,8 +294,6 @@ def get_from_env_or_user_or_default(environ_cp, var_name, ask_for_var,
   if not var:
     var = var_default
   return var
-
-
 
 
 def prompt_loop_or_load_from_env(environ_cp,
@@ -474,6 +470,7 @@ def main():
 
   #config_info_line('gdr', 'Build with GDR support.')
   #config_info_line('verbs', 'Build with libverbs support.')
+
 
 if __name__ == '__main__':
   main()

--- a/tensorflow_networking/.clang-format
+++ b/tensorflow_networking/.clang-format
@@ -1,0 +1,4 @@
+# Run manually to reformat a file:
+# clang-format -i --style=file <file>
+BasedOnStyle: Google
+DerivePointerAlignment: false

--- a/tensorflow_networking/gdr/BUILD
+++ b/tensorflow_networking/gdr/BUILD
@@ -13,7 +13,6 @@ filegroup(
     ]),
 )
 
-
 # For platform specific build config
 load(
     "@org_tensorflow//tensorflow/core:platform/default/build_config.bzl",
@@ -34,12 +33,12 @@ cc_library(
     srcs = ["gdr_memory_manager.cc"],
     hdrs = ["gdr_memory_manager.h"],
     linkopts = [
-            "-libverbs",
-            "-lrdmacm",
+        "-libverbs",
+        "-lrdmacm",
     ],
     deps = [
         ":gdr_proto_cc",
-        "@org_tensorflow//tensorflow/core:core",
+        "@org_tensorflow//tensorflow/core",
     ],
 )
 
@@ -49,7 +48,7 @@ cc_library(
     hdrs = ["gdr_worker.h"],
     deps = [
         ":gdr_memory_manager",
-        "@org_tensorflow//tensorflow/core:core",
+        "@org_tensorflow//tensorflow/core",
         "@org_tensorflow//tensorflow/core/distributed_runtime:graph_mgr",
         "@org_tensorflow//tensorflow/core/distributed_runtime:recent_request_ids",
         "@org_tensorflow//tensorflow/core/distributed_runtime:rendezvous_mgr_interface",
@@ -69,7 +68,7 @@ cc_library(
     hdrs = ["gdr_rendezvous_mgr.h"],
     deps = [
         ":gdr_memory_manager",
-        "@org_tensorflow//tensorflow/core:core",
+        "@org_tensorflow//tensorflow/core",
         "@org_tensorflow//tensorflow/core/distributed_runtime:base_rendezvous_mgr",
         "@org_tensorflow//tensorflow/core/distributed_runtime:request_id",
         "@org_tensorflow//tensorflow/core/distributed_runtime:tensor_coding",

--- a/tensorflow_networking/mpi/mpi_rendezvous_mgr.cc
+++ b/tensorflow_networking/mpi/mpi_rendezvous_mgr.cc
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-
 #include <chrono>
 #include <functional>
 #include <memory>

--- a/tensorflow_networking/mpi/mpi_rendezvous_mgr.h
+++ b/tensorflow_networking/mpi/mpi_rendezvous_mgr.h
@@ -26,7 +26,6 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-
 #include "tensorflow/core/distributed_runtime/base_rendezvous_mgr.h"
 #include "tensorflow/core/distributed_runtime/recent_request_ids.h"
 #include "tensorflow/core/distributed_runtime/request_id.h"

--- a/tensorflow_networking/mpi/mpi_server_lib.cc
+++ b/tensorflow_networking/mpi/mpi_server_lib.cc
@@ -106,4 +106,3 @@ static MPIServerRegistrar registrar;
 
 }  // namespace
 }  // namespace tensorflow
-

--- a/tensorflow_networking/mpi/mpi_server_lib.h
+++ b/tensorflow_networking/mpi/mpi_server_lib.h
@@ -18,8 +18,8 @@ limitations under the License.
 
 #include <memory>
 
-#include "tensorflow_networking/mpi/mpi_rendezvous_mgr.h"
 #include "tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h"
+#include "tensorflow_networking/mpi/mpi_rendezvous_mgr.h"
 
 namespace tensorflow {
 

--- a/tensorflow_networking/mpi/mpi_utils.h
+++ b/tensorflow_networking/mpi/mpi_utils.h
@@ -20,8 +20,8 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/lib/strings/str_util.h"
+#include "tensorflow/core/platform/logging.h"
 
 // Skip MPI C++ bindings support, this matches the usage in other places
 #define OMPI_SKIP_MPICXX

--- a/tensorflow_networking/mpi_collectives/kernels/mpi_ops.cc
+++ b/tensorflow_networking/mpi_collectives/kernels/mpi_ops.cc
@@ -34,9 +34,9 @@ limitations under the License.
 #include "tensorflow/stream_executor/lib/statusor.h"
 
 #define OMPI_SKIP_MPICXX
-#include "third_party/mpi/mpi.h"
 #include "tensorflow_networking/mpi_collectives/kernels/ring.h"
 #include "tensorflow_networking/mpi_collectives/mpi_message.pb.h"
+#include "third_party/mpi/mpi.h"
 
 /*
  * MPI Allreduce and Allgather Ops for TensorFlow.

--- a/tensorflow_networking/mpi_collectives/kernels/ring.h
+++ b/tensorflow_networking/mpi_collectives/kernels/ring.h
@@ -22,8 +22,8 @@ limitations under the License.
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/shape_inference.h"
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/tensor_types.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 #if GOOGLE_CUDA
 #include "cuda_runtime.h"

--- a/tensorflow_networking/mpi_collectives/mpi_ops.cc
+++ b/tensorflow_networking/mpi_collectives/mpi_ops.cc
@@ -35,9 +35,9 @@ limitations under the License.
 #include "tensorflow/stream_executor/lib/statusor.h"
 
 #define OMPI_SKIP_MPICXX
-#include "third_party/mpi/mpi.h"
 #include "tensorflow_networking/mpi_collectives/mpi_message.pb.h"
 #include "tensorflow_networking/mpi_collectives/ring.h"
+#include "third_party/mpi/mpi.h"
 
 /*
  * MPI Allreduce and Allgather Ops for TensorFlow.

--- a/tensorflow_networking/mpi_collectives/ring.h
+++ b/tensorflow_networking/mpi_collectives/ring.h
@@ -22,8 +22,8 @@ limitations under the License.
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/shape_inference.h"
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/tensor_types.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 #if GOOGLE_CUDA
 #include "cuda_runtime.h"

--- a/tensorflow_networking/repo.bzl
+++ b/tensorflow_networking/repo.bzl
@@ -36,32 +36,34 @@ def _apply_patch(ctx, patch_file):
     _execute_and_check_ret_code(ctx, cmd)
 
 def _tensorflow_http_archive(ctx):
-  git_commit = ctx.attr.git_commit
-  sha256 = ctx.attr.sha256
+    git_commit = ctx.attr.git_commit
+    sha256 = ctx.attr.sha256
 
-  override_git_commit = ctx.os.environ.get(_TF_REVISION)
-  if override_git_commit:
-    sha256 = ""
-    git_commit = override_git_commit
+    override_git_commit = ctx.os.environ.get(_TF_REVISION)
+    if override_git_commit:
+        sha256 = ""
+        git_commit = override_git_commit
 
-  strip_prefix = "tensorflow-%s" % git_commit
-  urls = [
-      "https://mirror.bazel.build/github.com/tensorflow/tensorflow/archive/%s.tar.gz" % git_commit,
-      "https://github.com/tensorflow/tensorflow/archive/%s.tar.gz" % git_commit,
-  ]
-  ctx.download_and_extract(
-      urls,
-      "",
-      sha256,
-      "",
-      strip_prefix)
-  if ctx.attr.patch != None:
-    _apply_patch(ctx, ctx.attr.patch)
+    strip_prefix = "tensorflow-%s" % git_commit
+    urls = [
+        "https://mirror.bazel.build/github.com/tensorflow/tensorflow/archive/%s.tar.gz" % git_commit,
+        "https://github.com/tensorflow/tensorflow/archive/%s.tar.gz" % git_commit,
+    ]
+    ctx.download_and_extract(
+        urls,
+        "",
+        sha256,
+        "",
+        strip_prefix,
+    )
+    if ctx.attr.patch != None:
+        _apply_patch(ctx, ctx.attr.patch)
 
 tensorflow_http_archive = repository_rule(
-    implementation=_tensorflow_http_archive,
-    attrs={
-        "git_commit": attr.string(mandatory=True),
-        "sha256": attr.string(mandatory=True),
+    attrs = {
+        "git_commit": attr.string(mandatory = True),
+        "sha256": attr.string(mandatory = True),
         "patch": attr.label(),
-    })
+    },
+    implementation = _tensorflow_http_archive,
+)

--- a/tensorflow_networking/verbs/grpc_verbs_client.h
+++ b/tensorflow_networking/verbs/grpc_verbs_client.h
@@ -16,11 +16,11 @@ limitations under the License.
 #ifndef TENSORFLOW_CONTRIB_VERBS_GRPC_VERBS_CLIENT_H_
 #define TENSORFLOW_CONTRIB_VERBS_GRPC_VERBS_CLIENT_H_
 
-#include "tensorflow_networking/verbs/grpc_verbs_service_impl.h"
-#include "tensorflow_networking/verbs/verbs_service.pb.h"
 #include "tensorflow/core/distributed_runtime/call_options.h"
 #include "tensorflow/core/distributed_runtime/rpc/grpc_util.h"
 #include "tensorflow/core/lib/core/status.h"
+#include "tensorflow_networking/verbs/grpc_verbs_service_impl.h"
+#include "tensorflow_networking/verbs/verbs_service.pb.h"
 
 namespace tensorflow {
 

--- a/tensorflow_networking/verbs/grpc_verbs_service.cc
+++ b/tensorflow_networking/verbs/grpc_verbs_service.cc
@@ -17,9 +17,9 @@ limitations under the License.
 #include "grpcpp/grpcpp.h"
 #include "grpcpp/server_builder.h"
 
-#include "tensorflow_networking/verbs/grpc_verbs_service.h"
 #include "tensorflow/core/distributed_runtime/rpc/grpc_util.h"
 #include "tensorflow/core/distributed_runtime/session_mgr.h"
+#include "tensorflow_networking/verbs/grpc_verbs_service.h"
 
 namespace tensorflow {
 

--- a/tensorflow_networking/verbs/grpc_verbs_service.h
+++ b/tensorflow_networking/verbs/grpc_verbs_service.h
@@ -16,12 +16,12 @@ limitations under the License.
 #ifndef TENSORFLOW_CONTRIB_VERBS_GRPC_VERBS_SERVICE_H_
 #define TENSORFLOW_CONTRIB_VERBS_GRPC_VERBS_SERVICE_H_
 
-#include "tensorflow_networking/verbs/grpc_verbs_service_impl.h"
-#include "tensorflow_networking/verbs/rdma_mgr.h"
-#include "tensorflow_networking/verbs/verbs_service.pb.h"
 #include "tensorflow/core/distributed_runtime/rpc/async_service_interface.h"
 #include "tensorflow/core/distributed_runtime/rpc/grpc_call.h"
 #include "tensorflow/core/lib/core/refcount.h"
+#include "tensorflow_networking/verbs/grpc_verbs_service_impl.h"
+#include "tensorflow_networking/verbs/rdma_mgr.h"
+#include "tensorflow_networking/verbs/verbs_service.pb.h"
 
 namespace grpc {
 class ServerBuilder;

--- a/tensorflow_networking/verbs/rdma.cc
+++ b/tensorflow_networking/verbs/rdma.cc
@@ -16,11 +16,11 @@ limitations under the License.
 #include <fcntl.h>
 #include <cstdlib>
 
-#include "tensorflow_networking/verbs/rdma.h"
-#include "tensorflow_networking/verbs/verbs_service.pb.h"
 #include "tensorflow/core/common_runtime/device_mgr.h"
 #include "tensorflow/core/common_runtime/dma_helper.h"
 #include "tensorflow/core/common_runtime/process_util.h"
+#include "tensorflow_networking/verbs/rdma.h"
+#include "tensorflow_networking/verbs/verbs_service.pb.h"
 #if GOOGLE_CUDA
 #include "tensorflow/core/common_runtime/gpu/gpu_process_state.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_util.h"

--- a/tensorflow_networking/verbs/rdma.h
+++ b/tensorflow_networking/verbs/rdma.h
@@ -25,7 +25,6 @@ limitations under the License.
 #include <unordered_map>
 #include <vector>
 
-#include "tensorflow_networking/verbs/verbs_util.h"
 #include "tensorflow/core/distributed_runtime/worker_env.h"
 #include "tensorflow/core/framework/rendezvous.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -33,6 +32,7 @@ limitations under the License.
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/mutex.h"
+#include "tensorflow_networking/verbs/verbs_util.h"
 
 namespace tensorflow {
 #define PKEY_DEFAULT 0

--- a/tensorflow_networking/verbs/rdma_mgr.cc
+++ b/tensorflow_networking/verbs/rdma_mgr.cc
@@ -16,8 +16,6 @@ limitations under the License.
 #include "tensorflow_networking/verbs/rdma_mgr.h"
 #include <fstream>
 #include <vector>
-#include "tensorflow_networking/verbs/grpc_verbs_client.h"
-#include "tensorflow_networking/verbs/verbs_service.pb.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_process_state.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_util.h"
 #include "tensorflow/core/common_runtime/pool_allocator.h"
@@ -27,6 +25,8 @@ limitations under the License.
 #include "tensorflow/core/framework/allocator_registry.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/lib/strings/strcat.h"
+#include "tensorflow_networking/verbs/grpc_verbs_client.h"
+#include "tensorflow_networking/verbs/verbs_service.pb.h"
 
 namespace tensorflow {
 

--- a/tensorflow_networking/verbs/rdma_mgr.h
+++ b/tensorflow_networking/verbs/rdma_mgr.h
@@ -19,9 +19,9 @@ limitations under the License.
 #include <string>
 #include <unordered_map>
 
-#include "tensorflow_networking/verbs/rdma.h"
 #include "tensorflow/core/distributed_runtime/rpc/grpc_channel.h"
 #include "tensorflow/core/distributed_runtime/worker_env.h"
+#include "tensorflow_networking/verbs/rdma.h"
 
 namespace tensorflow {
 

--- a/tensorflow_networking/verbs/rdma_rendezvous_mgr.cc
+++ b/tensorflow_networking/verbs/rdma_rendezvous_mgr.cc
@@ -15,13 +15,13 @@ limitations under the License.
 
 #include "tensorflow_networking/verbs/rdma_rendezvous_mgr.h"
 #include <unordered_set>
-#include "tensorflow_networking/verbs/verbs_util.h"
 #include "tensorflow/core/common_runtime/device.h"
 #include "tensorflow/core/common_runtime/device_mgr.h"
 #include "tensorflow/core/common_runtime/dma_helper.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/strings/numbers.h"
 #include "tensorflow/core/lib/strings/str_util.h"
+#include "tensorflow_networking/verbs/verbs_util.h"
 
 namespace tensorflow {
 

--- a/tensorflow_networking/verbs/rdma_rendezvous_mgr.h
+++ b/tensorflow_networking/verbs/rdma_rendezvous_mgr.h
@@ -16,10 +16,10 @@ limitations under the License.
 #ifndef TENSORFLOW_CONTRIB_VERBS_RDMA_RENDEZVOUS_MGR_H_
 #define TENSORFLOW_CONTRIB_VERBS_RDMA_RENDEZVOUS_MGR_H_
 
-#include "tensorflow_networking/verbs/rdma_mgr.h"
 #include "tensorflow/core/distributed_runtime/base_rendezvous_mgr.h"
 #include "tensorflow/core/distributed_runtime/worker_env.h"
 #include "tensorflow/core/platform/macros.h"
+#include "tensorflow_networking/verbs/rdma_mgr.h"
 
 namespace tensorflow {
 

--- a/tensorflow_networking/verbs/verbs_server_lib.cc
+++ b/tensorflow_networking/verbs/verbs_server_lib.cc
@@ -17,11 +17,11 @@ limitations under the License.
 
 #include "grpc/support/alloc.h"
 
-#include "tensorflow_networking/verbs/rdma_mgr.h"
-#include "tensorflow_networking/verbs/rdma_rendezvous_mgr.h"
 #include "tensorflow/core/distributed_runtime/server_lib.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/env.h"
+#include "tensorflow_networking/verbs/rdma_mgr.h"
+#include "tensorflow_networking/verbs/rdma_rendezvous_mgr.h"
 
 namespace tensorflow {
 

--- a/tensorflow_networking/verbs/verbs_server_lib.h
+++ b/tensorflow_networking/verbs/verbs_server_lib.h
@@ -16,9 +16,9 @@ limitations under the License.
 #ifndef TENSORFLOW_CONTRIB_VERBS_VERBS_SERVER_LIB_H_
 #define TENSORFLOW_CONTRIB_VERBS_VERBS_SERVER_LIB_H_
 
+#include "tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h"
 #include "tensorflow_networking/verbs/grpc_verbs_service.h"
 #include "tensorflow_networking/verbs/rdma_mgr.h"
-#include "tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h"
 
 namespace tensorflow {
 

--- a/third_party/mpi/mpi.bzl
+++ b/third_party/mpi/mpi.bzl
@@ -2,12 +2,13 @@
 # based on the configuration options return one or the other
 
 def mpi_hdr():
-    return if_openmpi(["mpi.h", "mpi_portable_platform.h"],
-                      ["mpi.h", "mpio.h", "mpicxx.h"])
+    return if_openmpi(
+        ["mpi.h", "mpi_portable_platform.h"],
+        ["mpi.h", "mpio.h", "mpicxx.h"],
+    )
 
 def if_openmpi(if_true, if_false = []):
     return select({
         "//tensorflow_networking:mpi_library_is_openmpi_based": if_true,
         "//conditions:default": if_false,
     })
-


### PR DESCRIPTION
Apply `clang-format` manually to fix styling of source files.

TODO: find an auto-formatting tool for each PR submission.