### PR TITLE
Fix rename to grpc as TF core dependency which breaks repo rule

### DIFF
--- a/third_party/tensorflow/tf_configure.bzl
+++ b/third_party/tensorflow/tf_configure.bzl
@@ -195,7 +195,7 @@ def _tf_pip_impl(repository_ctx):
         "farmhash_header_include",
     )
 
-    grpc_header_dir = "%s/%s" % (tf_header_dir, "external/grpc/include")
+    grpc_header_dir = "%s/%s" % (tf_header_dir, "external/com_github_grpc_grpc/include")
     grpc_header_rule = _symlink_genrule_for_dir(
         repository_ctx,
         grpc_header_dir,


### PR DESCRIPTION
See https://github.com/tensorflow/tensorflow/commit/f396035891b0938364ea247a7dd243a147930c6e for the change in core.