### PR TITLE
Fix rename to TF thread annotation macros

### DIFF
--- a/tensorflow_networking/gdr/gdr_memory_manager.cc
+++ b/tensorflow_networking/gdr/gdr_memory_manager.cc
@@ -15,15 +15,15 @@ limitations under the License.
 
 #include "tensorflow_networking/gdr/gdr_memory_manager.h"
 
+#include <fcntl.h>
+#include <rdma/rdma_cma.h>
+#include <rdma/rdma_verbs.h>
+
 #include <atomic>
 #include <cerrno>
 #include <fstream>
 #include <list>
 #include <map>
-
-#include <fcntl.h>
-#include <rdma/rdma_cma.h>
-#include <rdma/rdma_verbs.h>
 
 #include "tensorflow/core/common_runtime/device.h"
 #include "tensorflow/core/common_runtime/dma_helper.h"
@@ -34,7 +34,6 @@ limitations under the License.
 #include "tensorflow/core/platform/macros.h"
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/numa.h"
-
 #include "tensorflow_networking/gdr/gdr.pb.h"
 
 namespace tensorflow {
@@ -155,21 +154,22 @@ class GdrMemoryManager : public RemoteMemoryManager {
 
   // Server side on-the-fly tensor buffers
   mutex buf_mu_;
-  std::map<TensorKey, const TensorBuffer*> tensor_buffers_ GUARDED_BY(buf_mu_);
+  std::map<TensorKey, const TensorBuffer*> tensor_buffers_
+      TF_GUARDED_BY(buf_mu_);
 
   // Client side endpoints
   mutex client_mu_;
   std::map<std::pair<string, string>, RdmaEndpointPtr> clients_
-      GUARDED_BY(client_mu_);
+      TF_GUARDED_BY(client_mu_);
 
   // Client side callbacks
   mutex callback_mu_;
   std::map<TensorKey, StatusCallback> tensor_callbacks_
-      GUARDED_BY(callback_mu_);
+      TF_GUARDED_BY(callback_mu_);
 
   // Managed memory regions
   mutex alloc_mu_;
-  std::vector<MemoryRegionPtr> mrs_ GUARDED_BY(alloc_mu_);
+  std::vector<MemoryRegionPtr> mrs_ TF_GUARDED_BY(alloc_mu_);
 
   TF_DISALLOW_COPY_AND_ASSIGN(GdrMemoryManager);
 };

--- a/tensorflow_networking/gdr/gdr_rendezvous_mgr.cc
+++ b/tensorflow_networking/gdr/gdr_rendezvous_mgr.cc
@@ -112,7 +112,7 @@ class GdrRecvTensorCall : public BaseRecvTensorCall {
   Rendezvous::Args recv_args_;
 
   mutable mutex mu_;
-  Status status_ GUARDED_BY(mu_);
+  Status status_ TF_GUARDED_BY(mu_);
 
   TF_DISALLOW_COPY_AND_ASSIGN(GdrRecvTensorCall);
 };

--- a/tensorflow_networking/gdr/gdr_server_lib.h
+++ b/tensorflow_networking/gdr/gdr_server_lib.h
@@ -17,7 +17,6 @@ limitations under the License.
 #define TENSORFLOW_CONTRIB_GDR_GDR_SERVER_LIB_H_
 
 #include "tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h"
-
 #include "tensorflow_networking/gdr/gdr_memory_manager.h"
 
 namespace tensorflow {
@@ -45,7 +44,7 @@ class GdrServer : public GrpcServer {
   mutex mu_;
 
   std::unique_ptr<RemoteMemoryManager> remote_memory_manager_;
-  std::unique_ptr<Thread> gdr_thread_ GUARDED_BY(mu_);
+  std::unique_ptr<Thread> gdr_thread_ TF_GUARDED_BY(mu_);
 };
 
 }  // namespace tensorflow

--- a/tensorflow_networking/mpi/mpi_rendezvous_mgr.h
+++ b/tensorflow_networking/mpi/mpi_rendezvous_mgr.h
@@ -31,7 +31,6 @@ limitations under the License.
 #include "tensorflow/core/distributed_runtime/request_id.h"
 #include "tensorflow/core/distributed_runtime/worker_env.h"
 #include "tensorflow/core/protobuf/worker.pb.h"
-
 #include "tensorflow_networking/mpi/mpi_msg.pb.h"
 #include "tensorflow_networking/mpi/mpi_utils.h"
 
@@ -173,10 +172,10 @@ class MPIRendezvousMgr : public BaseRendezvousMgr {
   mutex msq_;
   mutex mrq_;
 
-  std::queue<SendQueueEntry> send_queue_ GUARDED_BY(msq_);
-  std::queue<RequestQueueEntry> request_queue_ GUARDED_BY(mrq_);
+  std::queue<SendQueueEntry> send_queue_ TF_GUARDED_BY(msq_);
+  std::queue<RequestQueueEntry> request_queue_ TF_GUARDED_BY(mrq_);
   std::map<std::string, std::shared_ptr<MPIRequestTensorCall>> recv_tensor_map_
-      GUARDED_BY(mrq_);
+      TF_GUARDED_BY(mrq_);
 
   RecentRequestIds recv_tensor_recent_request_ids_;
 

--- a/tensorflow_networking/verbs/grpc_verbs_service.h
+++ b/tensorflow_networking/verbs/grpc_verbs_service.h
@@ -19,7 +19,6 @@ limitations under the License.
 #include "grpcpp/alarm.h"
 #include "grpcpp/grpcpp.h"
 #include "grpcpp/server_builder.h"
-
 #include "tensorflow/core/distributed_runtime/rpc/async_service_interface.h"
 #include "tensorflow/core/distributed_runtime/rpc/grpc_call.h"
 #include "tensorflow/core/lib/core/refcount.h"
@@ -49,7 +48,7 @@ class GrpcVerbsService : public AsyncServiceInterface {
   ::grpc::ServerCompletionQueue* cq_;
   grpc::VerbsService::AsyncService verbs_service_;
   mutex shutdown_mu_;
-  bool is_shutdown_ GUARDED_BY(shutdown_mu_);
+  bool is_shutdown_ TF_GUARDED_BY(shutdown_mu_);
   ::grpc::Alarm* shutdown_alarm_;
   // not owned
   RdmaMgr* rdma_mgr_;

--- a/tensorflow_networking/verbs/rdma.h
+++ b/tensorflow_networking/verbs/rdma.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_CONTRIB_VERBS_RDMA_H_
 
 #include <infiniband/verbs.h>
+
 #include <cstring>  // for memset
 #include <functional>
 #include <memory>  // for shared_ptr
@@ -224,7 +225,7 @@ class RdmaMemoryMgr {
 
   // Managed memory regions
   mutex mrs_mu_;
-  std::vector<MemoryRegionPtr> mrs_ GUARDED_BY(mrs_mu_);
+  std::vector<MemoryRegionPtr> mrs_ TF_GUARDED_BY(mrs_mu_);
 };
 
 // RdmaTensorRequest
@@ -456,16 +457,16 @@ class RdmaChannel {
   string remote_name_;
   ibv_qp* qp_;
   mutex mu_;
-  bool connected_ GUARDED_BY(mu_) = false;
-  RdmaAddress remote_ GUARDED_BY(mu_);
-  bool remote_set_ GUARDED_BY(mu_) = false;
+  bool connected_ TF_GUARDED_BY(mu_) = false;
+  RdmaAddress remote_ TF_GUARDED_BY(mu_);
+  bool remote_set_ TF_GUARDED_BY(mu_) = false;
   mutex ct_mu_;
   typedef std::unordered_map<uint32_t, RdmaTensorRequest> RequestTable;
-  RequestTable request_table_ GUARDED_BY(ct_mu_);
-  uint32_t request_serial_ GUARDED_BY(ct_mu_);
+  RequestTable request_table_ TF_GUARDED_BY(ct_mu_);
+  uint32_t request_serial_ TF_GUARDED_BY(ct_mu_);
   mutex responses_mu_;
   typedef std::unordered_map<uint32_t, RdmaTensorResponse> ResponsesTable;
-  ResponsesTable responses_table_ GUARDED_BY(responses_mu_);
+  ResponsesTable responses_table_ TF_GUARDED_BY(responses_mu_);
   RdmaMessageBuffer* tx_message_buffer_;
   RdmaMessageBuffer* rx_message_buffer_;
   std::vector<RdmaMessageBuffer*> message_buffers_;
@@ -514,9 +515,9 @@ class RdmaMessageBuffer {
   ibv_mr* self_ = nullptr;
   mutex mu_;
   RemoteMR remote_;
-  std::queue<string> queue_ GUARDED_BY(mu_);
-  BufferStatus local_status_ GUARDED_BY(mu_) = none;
-  BufferStatus remote_status_ GUARDED_BY(mu_) = none;
+  std::queue<string> queue_ TF_GUARDED_BY(mu_);
+  BufferStatus local_status_ TF_GUARDED_BY(mu_) = none;
+  BufferStatus remote_status_ TF_GUARDED_BY(mu_) = none;
 };
 
 }  // namespace tensorflow

--- a/tensorflow_networking/verbs/verbs_server_lib.h
+++ b/tensorflow_networking/verbs/verbs_server_lib.h
@@ -51,10 +51,10 @@ class VerbsServer : public GrpcServer {
   mutex mu_;
 
   enum State { DISCONNECTED, CONNECTED };
-  State verbs_state_ GUARDED_BY(mu_);
+  State verbs_state_ TF_GUARDED_BY(mu_);
 
   GrpcVerbsService* verbs_service_ = nullptr;
-  std::unique_ptr<Thread> verbs_thread_ GUARDED_BY(mu_);
+  std::unique_ptr<Thread> verbs_thread_ TF_GUARDED_BY(mu_);
   GrpcChannelCache* channel_cache_ = nullptr;
 };
 


### PR DESCRIPTION
See https://github.com/tensorflow/tensorflow/commit/83d65b152b6b1ed1e622c59d908e76d8d2e7d07b for the change in core.