### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tensorflow_networking/mpi_collectives/__init__.py
+++ b/tensorflow_networking/mpi_collectives/__init__.py
@@ -136,7 +136,7 @@ from tensorflow.contrib.mpi_collectives.python.ops.mpi_ops import _allreduce
 def allreduce(tensor, average=True):
   """Perform an MPI allreduce on a tf.Tensor or tf.IndexedSlices.
 
-  Arguments:
+  Args:
   tensor: tf.Tensor, tf.Variable, or tf.IndexedSlices to reduce.
           The shape of the input must be identical across all ranks.
   average: If True, computes the average over all ranks.


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420